### PR TITLE
Added expiration of data in yagi. 

### DIFF
--- a/yagi/persistence/__init__.py
+++ b/yagi/persistence/__init__.py
@@ -6,6 +6,9 @@ yagi.config.defaults('persistence',
                      'yagi.persistence.devnull.Driver')
 
 
+class InvalidEntityUUID(KeyError): pass
+
+
 def persistence_driver():
     driver = yagi.config.get('persistence', 'driver')
     return yagi.utils.import_class(driver)()


### PR DESCRIPTION
expires content using redis expiry. Indexes are cleaned up next time the feeds are read. 
controlled by entry_ttl in [persistence], which is in seconds. default ttl  is 30 days. 
