### PR TITLE
Fix atom pub serializer. 

### DIFF
--- a/yagi/broker/rabbit.py
+++ b/yagi/broker/rabbit.py
@@ -61,7 +61,7 @@ class Broker(object):
                         msg.ack()
                 consumer.fetched_messages(messages)
             if poll_delay:
-                LOG.debug('Sleeping %s seconds...' % poll_delay)
+                #LOG.debug('Sleeping %s seconds...' % poll_delay)
                 time.sleep(poll_delay)
             else:
                 LOG.debug('Can\'t sleep... Insomnia.')

--- a/yagi/notifier/atompub.py
+++ b/yagi/notifier/atompub.py
@@ -24,7 +24,7 @@ def notify(notifications):
         #yagi.serializer.atom.dumps(notifications)
         entity = dict(content=notification,
                       id=notification['message_id'],
-                      event_type=['event_type'])
+                      event_type=notification['event_type'])
         notification_body = yagi.serializer.atom.dump_item(entity)
 
         headers = {'Content-Type': 'application/atom+xml'}


### PR DESCRIPTION
AtomPub was emiting the event type as "['event_type']" instead of the actual type. Fixed. 

Also, Removed 'Sleeping'.... spam from debug output.
