### PR TITLE
Added event_type to atom category tags

### DIFF
--- a/tests/unit/test_atompub.py
+++ b/tests/unit/test_atompub.py
@@ -54,7 +54,7 @@ class AtomPubTests(unittest.TestCase):
 
     def test_notify(self):
         messages = [{'event_type': 'instance_create',
-                     'id': 1,
+                     'message_id': 1,
                      'content': dict(a=3)}]
         self.called = False
         def mock_request(*args, **kwargs):
@@ -68,7 +68,7 @@ class AtomPubTests(unittest.TestCase):
     def test_notify_fails(self):
         messages = [
             { 'event_type': 'instance_create',
-              'id': 1,
+              'message_id': 1,
               'content': dict(a=3) }
         ]
         self.called = False

--- a/yagi/notifier/atompub.py
+++ b/yagi/notifier/atompub.py
@@ -54,6 +54,7 @@ def notify(notifications):
         except KeyError, e:
             LOG.error('Malformed Notification: %s' % notification)
             LOG.exception(e)
+            continue
 
         conn.follow_all_redirects = True
         puburl = topic_url(notification['event_type'])

--- a/yagi/serializer/atom.py
+++ b/yagi/serializer/atom.py
@@ -88,12 +88,13 @@ def dumps(entities, previous_page=None, next_page=None):
         next_page_url=("%s?page=%s" % (_entity_url(), next_page)) \
                           if next_page is not None else None)
     for entity in entities:
+        event_type=unicode(entity['event_type'])
         feed.add_item(
             title=unicode(entity['event_type']),
             link=_entity_link(entity['id'], entity['event_type']),
-            description=unicode(entity['event_type']),
+            description=event_type,
             contents=entity['content'],
-            categories=_categories())
+            categories=[event_type] + _categories())
     return feed.writeString('utf-8')
 
 
@@ -114,10 +115,11 @@ def dump_item(entity):
         previous_page_url=None,
         next_page_url=None)
 
+    event_type=unicode(entity['event_type'])
     feed.add_item(title=unicode(entity['event_type']),
                 link=_entity_link(entity['id'], entity['event_type']),
-                description=unicode(entity['event_type']),
+                description=event_type,
                 contents=entity['content'],
-                categories=_categories())
+                categories=[event_type] + _categories())
     feed.write_item(handler, feed.items[0], root=True)
     return outfile.getvalue()


### PR DESCRIPTION
added a <category></category> tag with the event_type to atom output for folks searching feeds by category.
Also, fixed broken unittests, and fixed exception thrown on malformed message due to debug statement. 
